### PR TITLE
feat(logging): add centralized logging with dictConfig and LOG_LEVEL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ GITHUB_ACCESS_TOKEN=ghp_your_token_here
 GITHUB_WEBHOOK_SECRET=your_webhook_secret_here
 DEFAULT_PROVIDER=cerebras
 DEFAULT_MODEL=meta-llama/Llama-3.1-8B-Instruct:cerebras
+# Logging level: DEBUG | INFO | WARNING | ERROR | CRITICAL (default: INFO)
+LOG_LEVEL=INFO
 HUGGING_FACE_API_KEY=hf_your_key_here
 
 # CORS (comma-separated list of allowed origins)

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ import hmac
 import logging
 import os
 import sys
+from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
@@ -13,6 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.api.v1.routes import router
 from backend.core.config import BackendConfig
 from src.core.config import Config
+from src.core.logging_config import configure_logging
 from src.reviewer.agent import review_pr, review_pr_debug
 
 logger = logging.getLogger(__name__)
@@ -51,7 +53,20 @@ async def _verify_github_signature(
 # FastAPI application
 # ---------------------------------------------------------------------------
 
-app = FastAPI(title="PR Code Reviewer API")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """FastAPI lifespan handler — configures logging on startup.
+
+    This ensures that direct ``uvicorn backend.main:app`` invocations (which
+    bypass ``main()``) still have logging configured before any request lands.
+    """
+    configure_logging()
+    logger.info("PR Reviewer backend started")
+    yield
+
+
+app = FastAPI(title="PR Code Reviewer API", lifespan=lifespan)
 
 # CORS middleware
 _cors_origins = [o.strip() for o in BackendConfig.CORS_ORIGINS.split(",") if o.strip()]
@@ -133,10 +148,7 @@ def _cli_review(repo_slug: str, pr_number: int, debug: bool = False) -> None:
     owner, repo = repo_slug.split("/", 1)
 
     if debug:
-        logging.basicConfig(
-            level=logging.DEBUG,
-            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        )
+        configure_logging("DEBUG")
         print(f"\n[DEBUG] Reviewing PR #{pr_number} in {owner}/{repo}\n{'=' * 60}")
         review_pr_debug(owner=owner, repo=repo, pr_number=pr_number)
         return
@@ -290,6 +302,7 @@ def _cli_graph(args: list[str]) -> None:
 
 
 def main() -> None:
+    configure_logging()
     args = sys.argv[1:]
 
     if not args:

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,7 +142,7 @@ async def github_webhook(
 
 def _cli_review(repo_slug: str, pr_number: int, debug: bool = False) -> None:
     if "/" not in repo_slug:
-        print(f"Error: repo must be in 'owner/repo' format, got '{repo_slug}'")
+        logger.error("repo must be in 'owner/repo' format, got '%s'", repo_slug)
         sys.exit(1)
 
     owner, repo = repo_slug.split("/", 1)
@@ -189,11 +189,11 @@ def _cli_graph(args: list[str]) -> None:
         try:
             driver = get_driver()
         except GraphError as exc:
-            print(f"Error: could not connect to Neo4j — {exc}")
+            logger.error("Could not connect to Neo4j — %s", exc)
             sys.exit(1)
 
         if not check_health():
-            print("Error: Neo4j is not reachable. Is it running?")
+            logger.error("Neo4j is not reachable. Is it running?")
             sys.exit(1)
 
         init_schema(driver)
@@ -213,22 +213,22 @@ def _cli_graph(args: list[str]) -> None:
         try:
             topology = load_topology(yaml_file)
         except FileNotFoundError as exc:
-            print(f"Error: {exc}")
+            logger.error("File not found: %s", exc)
             sys.exit(1)
         except Exception as exc:
-            print(f"Error: invalid topology file — {exc}")
+            logger.error("Invalid topology file — %s", exc)
             sys.exit(1)
 
         try:
             driver = get_driver()
         except GraphError as exc:
-            print(f"Error: could not connect to Neo4j — {exc}")
+            logger.error("Could not connect to Neo4j — %s", exc)
             sys.exit(1)
 
         try:
             stats = populate_graph(driver, topology)
         except Exception as exc:
-            print(f"Error: graph import failed — {exc}")
+            logger.error("Graph import failed — %s", exc)
             sys.exit(1)
 
         print(
@@ -258,7 +258,7 @@ def _cli_graph(args: list[str]) -> None:
         try:
             driver = get_driver()
         except GraphError as exc:
-            print(f"Error: could not connect to Neo4j — {exc}")
+            logger.error("Could not connect to Neo4j — %s", exc)
             sys.exit(1)
 
         try:
@@ -293,7 +293,7 @@ def _cli_graph(args: list[str]) -> None:
                 else:
                     print(f"Entity '{entity_name}' not found in the knowledge graph.")
         except Exception as exc:
-            print(f"Error: query failed — {exc}")
+            logger.error("Query failed — %s", exc)
             sys.exit(1)
 
     else:

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -15,6 +15,10 @@ import httpx
 import streamlit as st
 from streamlit import column_config
 
+from src.core.logging_config import configure_logging
+
+configure_logging()
+
 # ---------------------------------------------------------------------------
 # Backend URL configuration
 # ---------------------------------------------------------------------------

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,4 +1,17 @@
 from src.core.config import Config
-from src.core.exceptions import PRReviewerError, ProviderError, ConfigurationError, GitHubError
+from src.core.exceptions import (
+    PRReviewerError,
+    ProviderError,
+    ConfigurationError,
+    GitHubError,
+)
+from src.core.logging_config import configure_logging
 
-__all__ = ["Config", "PRReviewerError", "ProviderError", "ConfigurationError", "GitHubError"]
+__all__ = [
+    "Config",
+    "PRReviewerError",
+    "ProviderError",
+    "ConfigurationError",
+    "GitHubError",
+    "configure_logging",
+]

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -23,6 +23,9 @@ class Config:
     # GitHub
     GITHUB_ACCESS_TOKEN: str = os.getenv("GITHUB_ACCESS_TOKEN", "")
 
+    # Logging
+    LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
+
     # Default provider / model
     DEFAULT_MODEL: str = os.getenv("DEFAULT_MODEL", "moonshotai/Kimi-K2-Instruct")
     DEFAULT_PROVIDER: str = os.getenv("DEFAULT_PROVIDER", "huggingface")

--- a/src/core/logging_config.py
+++ b/src/core/logging_config.py
@@ -1,0 +1,116 @@
+"""Centralized logging configuration for pr-reviewer.
+
+Single source of truth for all logging setup across CLI, FastAPI, and Streamlit
+entrypoints. Call ``configure_logging()`` once per process — subsequent calls are
+no-ops (idempotent).
+"""
+
+import logging
+import logging.config
+import sys
+import warnings
+
+_configured: bool = False
+
+_VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+_THIRD_PARTY_LOGGERS = [
+    "uvicorn",
+    "uvicorn.access",
+    "uvicorn.error",
+    "httpx",
+    "agno",
+    "neo4j",
+    "neo4j.io",
+]
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Apply centralized logging configuration. Idempotent — second call is a no-op.
+
+    Args:
+        level: Desired log level for application loggers (``src.*`` and
+            ``backend.*``). When the caller passes the default ``"INFO"``, the
+            value of the ``LOG_LEVEL`` environment variable is used instead
+            (falling back to ``"INFO"`` if unset). Explicit non-default values
+            override the environment variable, which lets the CLI ``--debug``
+            flag force ``"DEBUG"`` unconditionally.
+
+    Invalid values fall back to ``"INFO"`` with a :func:`warnings.warn`
+    notification (the logger is not yet configured at that point, so we cannot
+    use it).
+    """
+    global _configured
+    if _configured:
+        return
+
+    # Resolve effective level: explicit param wins over env var.
+    if level == "INFO":
+        # Only read env var when caller did not override explicitly.
+        from src.core.config import Config  # local import to avoid circular deps
+
+        effective = Config.LOG_LEVEL
+    else:
+        effective = level
+
+    effective = effective.upper().strip()
+
+    if effective not in _VALID_LEVELS:
+        warnings.warn(
+            f"Invalid LOG_LEVEL={effective!r}, falling back to INFO",
+            stacklevel=2,
+        )
+        effective = "INFO"
+
+    # Build third-party logger entries — all pinned to WARNING.
+    tp_loggers: dict = {
+        name: {
+            "level": "WARNING",
+            "handlers": ["console"],
+            "propagate": False,
+        }
+        for name in _THIRD_PARTY_LOGGERS
+    }
+
+    config: dict = {
+        "version": 1,
+        # CRITICAL: must be False so that loggers created at import-time
+        # (before configure_logging runs) are not silenced by dictConfig.
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {
+                "format": (
+                    "%(asctime)s [%(levelname)s] %(name)s"
+                    " (%(filename)s:%(lineno)d): %(message)s"
+                ),
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                # ext:// prefix tells dictConfig to resolve the object reference.
+                "stream": "ext://sys.stdout",
+                "formatter": "standard",
+            },
+        },
+        "loggers": {
+            "src": {
+                "level": effective,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            "backend": {
+                "level": effective,
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            **tp_loggers,
+        },
+        "root": {
+            "level": "WARNING",
+            "handlers": ["console"],
+        },
+    }
+
+    logging.config.dictConfig(config)
+    _configured = True

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,259 @@
+"""Tests for src.core.logging_config — REQ-LOG-CONFIG through REQ-LOG-DISABLE-EXISTING."""
+
+import logging
+import logging.config
+import sys
+import warnings
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+import src.core.logging_config as lc_module
+from src.core.logging_config import configure_logging
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_configured_flag():
+    """Reset the module-level _configured flag before each test.
+
+    configure_logging() is idempotent — without this reset every test after
+    the first would be a no-op, making assertions meaningless.
+    """
+    original = lc_module._configured
+    lc_module._configured = False
+    yield
+    lc_module._configured = original
+
+
+@pytest.fixture(autouse=True)
+def clean_loggers():
+    """Remove handlers added by configure_logging() after each test.
+
+    dictConfig replaces existing handlers but we still want a clean slate
+    so that captured-output assertions don't bleed across tests. We also
+    restore propagate=True so that pytest's caplog fixture continues to
+    work in other test modules after our tests run.
+    """
+    yield
+    # Remove all handlers from root and known app loggers; restore defaults.
+    for name in ("", "src", "backend", *lc_module._THIRD_PARTY_LOGGERS):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.setLevel(logging.NOTSET)
+        if name != "":
+            # Restore propagation so pytest caplog works in other test modules.
+            lg.propagate = True
+
+
+# ---------------------------------------------------------------------------
+# 6.1 — REQ-LOG-CONFIG: module importable
+# ---------------------------------------------------------------------------
+
+
+class TestImportable:
+    def test_import_succeeds(self):
+        """configure_logging is importable without errors."""
+        # If this file runs at all, the import at the top already succeeded.
+        assert callable(configure_logging)
+
+
+# ---------------------------------------------------------------------------
+# 6.2 — REQ-LOG-APP / REQ-LOG-HANDLER: app loggers emit to stdout, propagate=False
+# ---------------------------------------------------------------------------
+
+
+class TestAppLoggerEmitsToStdout:
+    def test_debug_message_goes_to_stdout(self, monkeypatch, capsys):
+        """configure_logging(DEBUG) → src.* debug messages appear on stdout."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_logging("DEBUG")
+
+        logging.getLogger("src.test_module").debug("hello stdout")
+
+        captured = capsys.readouterr()
+        assert "hello stdout" in captured.out
+        assert captured.err == ""
+
+    def test_propagate_false_prevents_duplicate(self, monkeypatch):
+        """src logger has propagate=False so root does not re-emit the record."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_logging("DEBUG")
+
+        src_logger = logging.getLogger("src")
+        root_logger = logging.root
+
+        assert src_logger.propagate is False
+        # Root handler count should be 1 (the console handler we set), not 2.
+        assert len(root_logger.handlers) == 1
+
+    def test_format_contains_required_fields(self, monkeypatch, capsys):
+        """Formatted output includes timestamp, level, logger name, and message."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_logging("INFO")
+
+        logging.getLogger("src.format_test").info("check-format")
+
+        out = capsys.readouterr().out
+        # Timestamp: starts with a digit (year)
+        assert any(char.isdigit() for char in out.split()[0])
+        assert "[INFO]" in out
+        assert "src.format_test" in out
+        assert "check-format" in out
+
+
+# ---------------------------------------------------------------------------
+# 6.3 — REQ-LOG-LEVEL: default is INFO
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultLevel:
+    def test_unset_env_var_defaults_to_info(self, monkeypatch):
+        """When LOG_LEVEL env var is not set, effective level is INFO."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        # Patch Config.LOG_LEVEL to simulate missing env var
+        import src.core.config as cfg_module
+
+        monkeypatch.setattr(cfg_module.Config, "LOG_LEVEL", "INFO")
+
+        configure_logging()
+
+        src_logger = logging.getLogger("src")
+        assert src_logger.level == logging.INFO
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        """LOG_LEVEL=DEBUG env var → src.* loggers get DEBUG level."""
+        import src.core.config as cfg_module
+
+        monkeypatch.setattr(cfg_module.Config, "LOG_LEVEL", "DEBUG")
+
+        configure_logging()
+
+        src_logger = logging.getLogger("src")
+        assert src_logger.level == logging.DEBUG
+
+
+# ---------------------------------------------------------------------------
+# 6.4 — REQ-LOG-LEVEL: invalid value falls back safely
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidLevel:
+    def test_invalid_level_does_not_raise(self, monkeypatch):
+        """Invalid LOG_LEVEL=VERBOSE → no exception, falls back to INFO."""
+        import src.core.config as cfg_module
+
+        monkeypatch.setattr(cfg_module.Config, "LOG_LEVEL", "VERBOSE")
+
+        # Should not raise
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            configure_logging()
+
+        assert lc_module._configured is True
+
+    def test_invalid_level_emits_warning(self, monkeypatch):
+        """Invalid LOG_LEVEL → warnings.warn is called with a descriptive message."""
+        import src.core.config as cfg_module
+
+        monkeypatch.setattr(cfg_module.Config, "LOG_LEVEL", "BADLEVEL")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            configure_logging()
+
+        assert len(caught) == 1
+        assert "BADLEVEL" in str(caught[0].message)
+
+    def test_invalid_level_falls_back_to_info(self, monkeypatch):
+        """Invalid LOG_LEVEL → effective level is INFO (safe default)."""
+        import src.core.config as cfg_module
+
+        monkeypatch.setattr(cfg_module.Config, "LOG_LEVEL", "NONSENSE")
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            configure_logging()
+
+        src_logger = logging.getLogger("src")
+        assert src_logger.level == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# 6.5 — REQ-LOG-THIRDPARTY: third-party debug suppressed
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyLoggers:
+    def test_httpx_debug_suppressed(self, monkeypatch, capsys):
+        """LOG_LEVEL=DEBUG → httpx debug messages are NOT emitted."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_logging("DEBUG")
+
+        httpx_logger = logging.getLogger("httpx")
+        # isEnabledFor respects the logger's own level
+        assert not httpx_logger.isEnabledFor(logging.DEBUG)
+
+    def test_httpx_warning_visible(self, monkeypatch, capsys):
+        """Third-party loggers still emit at WARNING level."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_logging("DEBUG")
+
+        httpx_logger = logging.getLogger("httpx")
+        assert httpx_logger.isEnabledFor(logging.WARNING)
+
+    def test_all_third_party_pinned_to_warning(self, monkeypatch):
+        """All 7 third-party loggers are pinned at WARNING with propagate=False."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_logging("DEBUG")
+
+        for name in lc_module._THIRD_PARTY_LOGGERS:
+            lg = logging.getLogger(name)
+            assert lg.level == logging.WARNING, f"{name} should be WARNING"
+            assert lg.propagate is False, f"{name} should have propagate=False"
+
+
+# ---------------------------------------------------------------------------
+# 6.6 — REQ-LOG-DISABLE-EXISTING: pre-existing loggers not silenced
+# ---------------------------------------------------------------------------
+
+
+class TestDisableExistingLoggers:
+    def test_preexisting_logger_still_emits(self, monkeypatch, capsys):
+        """A logger created BEFORE configure_logging still works afterwards."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+        # Create logger BEFORE calling configure_logging (simulates import-time)
+        preexisting = logging.getLogger("src.preexisting_test")
+
+        configure_logging("DEBUG")
+
+        preexisting.debug("pre-existing-message")
+        out = capsys.readouterr().out
+        assert "pre-existing-message" in out
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_second_call_is_noop(self, monkeypatch):
+        """Calling configure_logging twice does not add duplicate handlers."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+        configure_logging("INFO")
+        handler_count_after_first = len(logging.getLogger("src").handlers)
+
+        # Reset the flag manually to simulate a second call reaching the gate
+        # NOTE: we do NOT reset — second call should hit the early return.
+        configure_logging("DEBUG")
+
+        handler_count_after_second = len(logging.getLogger("src").handlers)
+        assert handler_count_after_first == handler_count_after_second


### PR DESCRIPTION
## Summary

- Add centralized logging configuration using `dictConfig` with a single `StreamHandler` to stdout
- Configurable `LOG_LEVEL` env var (DEBUG/INFO/WARNING/ERROR/CRITICAL, default: INFO)
- Third-party loggers (uvicorn, httpx, agno, neo4j) pinned to WARNING to reduce noise
- Wired into all 3 entrypoints: CLI `main()`, FastAPI lifespan, Streamlit top-level

## Changes

| File | Change |
|------|--------|
| `src/core/logging_config.py` | **New** — `configure_logging()` with dictConfig, idempotency guard, level validation |
| `src/core/config.py` | Added `LOG_LEVEL` class attribute |
| `src/core/__init__.py` | Exported `configure_logging` |
| `backend/main.py` | Added `lifespan` handler, `configure_logging()` in `main()`, replaced `basicConfig` |
| `frontend/streamlit_app.py` | Added `configure_logging()` after imports |
| `.env.example` | Added `LOG_LEVEL=INFO` with docs |
| `tests/test_logging_config.py` | **New** — 14 tests covering all requirements |

## Test Plan

- [x] `uv run pytest` — 194/194 passing
- [x] Verified idempotency (double call does not duplicate handlers)
- [x] Verified invalid LOG_LEVEL falls back to INFO with warning
- [x] Verified third-party loggers suppressed at WARNING