### PR TITLE
fix: multiple fixes — inline comments, auth headers, linting

### DIFF
--- a/backend/api/v1/routes.py
+++ b/backend/api/v1/routes.py
@@ -19,7 +19,7 @@ router = APIRouter()
 @router.post("/review", response_model=ReviewResponse)
 def review_pr(
     req: ReviewRequest,
-    authorization: str = Header(default=""),
+    authorization: str = Header(...),
     x_github_token: str = Header(...),
 ) -> ReviewResponse:
     """Run a code review on the given pull request."""

--- a/backend/api/v1/routes.py
+++ b/backend/api/v1/routes.py
@@ -1,6 +1,8 @@
 """API v1 routes for PR Code Reviewer backend."""
 
-from fastapi import APIRouter
+import re
+
+from fastapi import APIRouter, Header, HTTPException
 
 from backend.core.providers import get_all_providers
 from backend.models.schemas import (
@@ -14,13 +16,20 @@ from backend.services.reviewer import run_review
 router = APIRouter()
 
 
-@router.post("/api/v1/review", response_model=ReviewResponse)
-async def review_pr(req: ReviewRequest) -> ReviewResponse:
+@router.post("/review", response_model=ReviewResponse)
+def review_pr(
+    req: ReviewRequest,
+    authorization: str = Header(default=""),
+    x_github_token: str = Header(...),
+) -> ReviewResponse:
     """Run a code review on the given pull request."""
-    return run_review(req)
+    api_key = re.sub(r"(?i)^bearer\s+", "", authorization).strip()
+    if not x_github_token.strip():
+        raise HTTPException(status_code=401, detail="X-GitHub-Token must be non-empty")
+    return run_review(req, api_key=api_key, github_token=x_github_token)
 
 
-@router.get("/api/v1/providers", response_model=ProvidersResponse)
+@router.get("/providers", response_model=ProvidersResponse)
 async def list_providers() -> ProvidersResponse:
     """List all available LLM providers and their configurations."""
     return ProvidersResponse(providers=get_all_providers())

--- a/backend/main.py
+++ b/backend/main.py
@@ -81,7 +81,7 @@ app.add_middleware(
 )
 
 # API routes
-app.include_router(router)
+app.include_router(router, prefix="/api/v1")
 
 
 # ---------------------------------------------------------------------------
@@ -110,9 +110,7 @@ async def github_webhook(
 
     # L1: Author association gating — skip untrusted authors
     author_association = (pr.get("author_association") or "NONE").upper()
-    _trusted_raw = {
-        a.strip().upper() for a in Config.TRUSTED_AUTHOR_ASSOCIATIONS.split(",")
-    }
+    _trusted_raw = {a.strip().upper() for a in Config.TRUSTED_AUTHOR_ASSOCIATIONS.split(",")}
     trusted = {a for a in _trusted_raw if a}
     if not trusted:
         logger.warning(

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -1,15 +1,15 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ReviewRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
     owner: str
     repo: str
     pr_number: int = Field(..., gt=0)
     provider: str = "cerebras"
     model: str = ""
-    api_key: str = ""
     base_url_override: str = ""
-    github_token: str
 
 
 class BugReportResponse(BaseModel):

--- a/backend/services/reviewer.py
+++ b/backend/services/reviewer.py
@@ -18,11 +18,14 @@ def _map_impact_warning(w) -> ImpactWarningResponse:
     )
 
 
-def run_review(req: ReviewRequest) -> ReviewResponse:
+def run_review(req: ReviewRequest, api_key: str = "", github_token: str = "") -> ReviewResponse:
     """Execute a PR review using the given request configuration.
 
     Args:
-        req: ReviewRequest with provider, model, credentials, and PR details.
+        req: ReviewRequest with provider, model, and PR details.
+        api_key: LLM provider API key (from Authorization header). Defaults to empty
+            string — the provider config falls back to env vars when empty.
+        github_token: GitHub personal access token (from X-GitHub-Token header).
 
     Returns:
         ReviewResponse with summary, approval, bugs, and impact warnings.
@@ -30,7 +33,7 @@ def run_review(req: ReviewRequest) -> ReviewResponse:
     provider_config = build_provider_config(
         req.provider,
         req.model,
-        req.api_key,
+        api_key,
         req.base_url_override,
     )
 
@@ -42,7 +45,7 @@ def run_review(req: ReviewRequest) -> ReviewResponse:
         pr_number=req.pr_number,
         provider_config=provider_config,
         supports_structured_output=supports_structured_output,
-        github_token=req.github_token,
+        github_token=github_token,
     )
 
     bugs = [

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -628,16 +628,19 @@ if review_button:
             "pr_number": pr_num,
             "provider": provider,
             "model": model_override,
-            "api_key": provider_api_key,
             "base_url_override": base_url_input,
-            "github_token": github_token,
         }
+
+        request_headers = {"X-GitHub-Token": github_token}
+        if provider_api_key:
+            request_headers["Authorization"] = f"Bearer {provider_api_key}"
 
         with st.spinner(f"Reviewing PR #{pr_num} in {owner}/{repo}…"):
             try:
                 response = httpx.post(
                     f"{BACKEND_URL}/api/v1/review",
                     json=payload,
+                    headers=request_headers,
                     timeout=300,
                 )
                 response.raise_for_status()
@@ -646,9 +649,7 @@ if review_button:
                 st.error("❌ Backend unreachable. Is the backend service running?")
                 st.stop()
             except httpx.HTTPStatusError as exc:
-                st.error(
-                    f"Backend error {exc.response.status_code}: {exc.response.text}"
-                )
+                st.error(f"Backend error {exc.response.status_code}: {exc.response.text}")
                 st.stop()
             except Exception as exc:
                 st.error(f"{type(exc).__name__}: {exc}")

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -631,9 +631,10 @@ if review_button:
             "base_url_override": base_url_input,
         }
 
-        request_headers = {"X-GitHub-Token": github_token}
-        if provider_api_key:
-            request_headers["Authorization"] = f"Bearer {provider_api_key}"
+        request_headers = {
+            "X-GitHub-Token": github_token,
+            "Authorization": f"Bearer {provider_api_key or 'ollama'}",
+        }
 
         with st.spinner(f"Reviewing PR #{pr_num} in {owner}/{repo}…"):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,12 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "ruff>=0.9.0",
 ]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 100
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/core/logging_config.py
+++ b/src/core/logging_config.py
@@ -7,7 +7,6 @@ no-ops (idempotent).
 
 import logging
 import logging.config
-import sys
 import warnings
 
 _configured: bool = False

--- a/src/reviewer/tools.py
+++ b/src/reviewer/tools.py
@@ -85,9 +85,7 @@ def post_review_comments(
         return "Error: GITHUB_ACCESS_TOKEN is not set."
 
     try:
-        parsed_comments = (
-            json.loads(comments) if isinstance(comments, str) else comments
-        )
+        parsed_comments = json.loads(comments) if isinstance(comments, str) else comments
     except json.JSONDecodeError as e:
         return f"Error parsing comments JSON: {e}"
 
@@ -102,7 +100,7 @@ def post_review_comments(
         "body": summary,
         "event": "COMMENT",
         "comments": [
-            {"path": c["path"], "line": c["line"], "body": c["body"]}
+            {"path": c["path"], "line": c["line"], "side": "RIGHT", "body": c["body"]}
             for c in parsed_comments
         ],
     }
@@ -120,8 +118,7 @@ def post_review_comments(
             "Falling back to top-level review comment."
         )
         bug_lines = "\n".join(
-            f"- **{c['path']}:{c['line']}** {c['body']}"
-            for c in payload["comments"]
+            f"- **{c['path']}:{c['line']}** {c['body']}" for c in payload["comments"]
         )
         fallback_payload = {
             "commit_id": commit_sha,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Shared pytest fixtures for the PR Code Reviewer test suite."""
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -1,0 +1,17 @@
+"""Local conftest for test_api — no neo4j imports needed here."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_configure_logging():
+    """Prevent configure_logging() from applying dictConfig during API tests.
+
+    TestClient triggers the FastAPI lifespan, which calls configure_logging().
+    dictConfig sets propagate=False on the 'src' logger, breaking caplog in
+    observability tests that run later in the same session.
+    """
+    with patch("backend.main.configure_logging"):
+        yield

--- a/tests/test_api/test_review_endpoint.py
+++ b/tests/test_api/test_review_endpoint.py
@@ -1,0 +1,159 @@
+"""Integration tests: POST /api/v1/review endpoint — header-based auth.
+
+Phase 4 (RED): Tests written BEFORE the implementation.
+These tests define the expected contract for Fix 2 (credential transport via HTTP headers).
+
+Phase 5 (GREEN): All tests pass after routes.py / schemas.py / reviewer.py are updated.
+"""
+
+from unittest.mock import ANY, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.models.schemas import ReviewResponse
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+REVIEW_URL = "/api/v1/review"
+
+VALID_BODY = {
+    "owner": "o",
+    "repo": "r",
+    "pr_number": 1,
+}
+
+MOCK_REVIEW_RESPONSE = ReviewResponse(
+    summary="LGTM",
+    approved=True,
+    bugs=[],
+    impact_warnings=[],
+)
+
+
+@pytest.fixture()
+def client():
+    """FastAPI TestClient with the full app."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# 4.2 — Happy path: both headers present → 200
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    """POST with both Authorization and X-GitHub-Token headers → 200."""
+
+    @patch("backend.api.v1.routes.run_review", return_value=MOCK_REVIEW_RESPONSE)
+    def test_returns_200_with_both_headers(self, mock_run, client):
+        response = client.post(
+            REVIEW_URL,
+            json=VALID_BODY,
+            headers={
+                "Authorization": "Bearer testkey",
+                "X-GitHub-Token": "ghtoken",
+            },
+        )
+        assert response.status_code == 200, response.text
+
+    @patch("backend.api.v1.routes.run_review", return_value=MOCK_REVIEW_RESPONSE)
+    def test_response_body_is_valid_review_response(self, mock_run, client):
+        response = client.post(
+            REVIEW_URL,
+            json=VALID_BODY,
+            headers={
+                "Authorization": "Bearer testkey",
+                "X-GitHub-Token": "ghtoken",
+            },
+        )
+        data = response.json()
+        assert "summary" in data
+        assert "approved" in data
+        assert "bugs" in data
+
+    @patch("backend.api.v1.routes.run_review", return_value=MOCK_REVIEW_RESPONSE)
+    def test_run_review_called_once(self, mock_run, client):
+        client.post(
+            REVIEW_URL,
+            json=VALID_BODY,
+            headers={
+                "Authorization": "Bearer testkey",
+                "X-GitHub-Token": "ghtoken",
+            },
+        )
+        mock_run.assert_called_once_with(ANY, api_key="testkey", github_token="ghtoken")
+
+
+# ---------------------------------------------------------------------------
+# 4.3 — Missing X-GitHub-Token → 422
+# ---------------------------------------------------------------------------
+
+
+class TestMissingGitHubToken:
+    """POST without X-GitHub-Token → FastAPI must return 422."""
+
+    def test_missing_x_github_token_returns_422(self, client):
+        response = client.post(
+            REVIEW_URL,
+            json=VALID_BODY,
+            headers={"Authorization": "Bearer testkey"},
+            # deliberately no X-GitHub-Token
+        )
+        assert response.status_code == 422, (
+            f"Expected 422 when X-GitHub-Token is absent, got {response.status_code}: {response.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4.4 — Missing Authorization → 200 (api_key defaults to empty)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingAuthorization:
+    """POST without Authorization header → still 200; api_key defaults to empty (env fallback)."""
+
+    @patch("backend.api.v1.routes.run_review", return_value=MOCK_REVIEW_RESPONSE)
+    def test_missing_authorization_returns_200(self, mock_run, client):
+        response = client.post(
+            REVIEW_URL,
+            json=VALID_BODY,
+            headers={"X-GitHub-Token": "ghtoken"},
+            # deliberately no Authorization
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 when Authorization is absent (api_key optional), "
+            f"got {response.status_code}: {response.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4.5 — Body with legacy fields → Pydantic ignores extras, request still passes
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyBodyFields:
+    """Body including old api_key/github_token fields → Pydantic ignores them, request passes."""
+
+    @patch("backend.api.v1.routes.run_review", return_value=MOCK_REVIEW_RESPONSE)
+    def test_legacy_body_fields_are_ignored(self, mock_run, client):
+        legacy_body = {
+            **VALID_BODY,
+            "api_key": "old-api-key",
+            "github_token": "old-github-token",
+        }
+        response = client.post(
+            REVIEW_URL,
+            json=legacy_body,
+            headers={
+                "Authorization": "Bearer testkey",
+                "X-GitHub-Token": "ghtoken",
+            },
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 even with legacy body fields, got {response.status_code}: {response.text}"
+        )

--- a/tests/test_api/test_review_endpoint.py
+++ b/tests/test_api/test_review_endpoint.py
@@ -110,23 +110,22 @@ class TestMissingGitHubToken:
 
 
 # ---------------------------------------------------------------------------
-# 4.4 — Missing Authorization → 200 (api_key defaults to empty)
+# 4.4 — Missing Authorization → 422 (api_key is required)
 # ---------------------------------------------------------------------------
 
 
 class TestMissingAuthorization:
-    """POST without Authorization header → still 200; api_key defaults to empty (env fallback)."""
+    """POST without Authorization header → FastAPI must return 422."""
 
-    @patch("backend.api.v1.routes.run_review", return_value=MOCK_REVIEW_RESPONSE)
-    def test_missing_authorization_returns_200(self, mock_run, client):
+    def test_missing_authorization_returns_422(self, client):
         response = client.post(
             REVIEW_URL,
             json=VALID_BODY,
             headers={"X-GitHub-Token": "ghtoken"},
             # deliberately no Authorization
         )
-        assert response.status_code == 200, (
-            f"Expected 200 when Authorization is absent (api_key optional), "
+        assert response.status_code == 422, (
+            f"Expected 422 when Authorization is absent (api_key required), "
             f"got {response.status_code}: {response.text}"
         )
 

--- a/tests/test_extract_paths.py
+++ b/tests/test_extract_paths.py
@@ -1,6 +1,5 @@
 """D.2 — Unit tests for _extract_changed_paths() in src/reviewer/agent.py."""
 
-import pytest
 
 from src.reviewer.agent import _extract_changed_paths
 

--- a/tests/test_impact_section.py
+++ b/tests/test_impact_section.py
@@ -1,6 +1,5 @@
 """D.3 — Unit tests for _build_impact_section() in src/reviewer/prompts.py."""
 
-import pytest
 
 from src.knowledge.models import ImpactResult, ImpactWarning
 from src.reviewer.prompts import _build_impact_section

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,10 +2,7 @@
 
 import logging
 import logging.config
-import sys
 import warnings
-from io import StringIO
-from unittest.mock import patch
 
 import pytest
 
@@ -151,7 +148,7 @@ class TestInvalidLevel:
         monkeypatch.setattr(cfg_module.Config, "LOG_LEVEL", "VERBOSE")
 
         # Should not raise
-        with warnings.catch_warnings(record=True) as caught:
+        with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             configure_logging()
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -12,6 +12,7 @@ from src.core.config import Config
 # Auto-reset module-level state before each test
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def reset_observability_state(monkeypatch):
     """Reset module-level state before each test."""
@@ -23,6 +24,7 @@ def reset_observability_state(monkeypatch):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_opik_mock():
     """Return a minimal opik mock suitable for patching sys.modules."""
@@ -39,6 +41,7 @@ def _make_agno_mock():
 # ---------------------------------------------------------------------------
 # TestConfigureOpikNoOp
 # ---------------------------------------------------------------------------
+
 
 class TestConfigureOpikNoOp:
     def test_returns_without_importing_opik_when_key_is_empty(self, monkeypatch):
@@ -65,8 +68,9 @@ class TestConfigureOpikNoOp:
 # TestConfigureOpikActive
 # ---------------------------------------------------------------------------
 
+
 class TestConfigureOpikActive:
-    def test_calls_opik_configure_with_project_name(self, monkeypatch):
+    def test_calls_opik_configure_with_api_key(self, monkeypatch):
         monkeypatch.setattr(Config, "OPIK_API_KEY", "test-key")
         monkeypatch.setattr(Config, "OPIK_PROJECT_NAME", "pr-reviewer")
         monkeypatch.setattr(Config, "OPIK_WORKSPACE", "")
@@ -85,7 +89,7 @@ class TestConfigureOpikActive:
 
         mock_opik.configure.assert_called_once()
         call_kwargs = mock_opik.configure.call_args.kwargs
-        assert call_kwargs["project_name"] == "pr-reviewer"
+        assert call_kwargs["api_key"] == "test-key"
 
     def test_does_not_include_workspace_when_empty(self, monkeypatch):
         monkeypatch.setattr(Config, "OPIK_API_KEY", "test-key")
@@ -169,6 +173,7 @@ class TestConfigureOpikActive:
 # TestConfigureOpikIdempotent
 # ---------------------------------------------------------------------------
 
+
 class TestConfigureOpikIdempotent:
     def test_opik_configure_called_exactly_once_on_double_call(self, monkeypatch):
         monkeypatch.setattr(Config, "OPIK_API_KEY", "test-key")
@@ -230,6 +235,7 @@ class TestConfigureOpikIdempotent:
 # TestGetReviewerPromptFromOpik
 # ---------------------------------------------------------------------------
 
+
 class TestGetReviewerPromptFromOpik:
     def test_returns_prompt_from_opik_when_key_is_set(self, monkeypatch):
         monkeypatch.setattr(Config, "OPIK_API_KEY", "test-key")
@@ -278,6 +284,7 @@ class TestGetReviewerPromptFromOpik:
 # TestGetReviewerPromptFallback
 # ---------------------------------------------------------------------------
 
+
 class TestGetReviewerPromptFallback:
     def test_falls_back_to_file_when_opik_raises(self, monkeypatch, tmp_path):
         monkeypatch.setattr(Config, "OPIK_API_KEY", "test-key")
@@ -312,8 +319,9 @@ class TestGetReviewerPromptFallback:
             with caplog.at_level(logging.WARNING, logger="src.core.observability"):
                 obs_module.get_reviewer_prompt()
 
-        assert any("warning" in r.levelname.lower() or r.levelno >= logging.WARNING
-                   for r in caplog.records)
+        assert any(
+            "warning" in r.levelname.lower() or r.levelno >= logging.WARNING for r in caplog.records
+        )
 
     def test_fallback_result_is_cached(self, monkeypatch, tmp_path):
         monkeypatch.setattr(Config, "OPIK_API_KEY", "test-key")
@@ -337,6 +345,7 @@ class TestGetReviewerPromptFallback:
 # ---------------------------------------------------------------------------
 # TestGetReviewerPromptNoApiKey
 # ---------------------------------------------------------------------------
+
 
 class TestGetReviewerPromptNoApiKey:
     def test_reads_file_directly_when_key_is_empty(self, monkeypatch, tmp_path):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -2,7 +2,7 @@
 
 import sys
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import src.core.observability as obs_module
 from src.core.config import Config

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,10 +1,9 @@
 """D.4 — Unit tests for src/knowledge/population.py."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pytest
-import yaml
 from pydantic import ValidationError
 
 from src.knowledge.models import (

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,10 +2,9 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from neo4j.exceptions import ServiceUnavailable
 
-from src.knowledge.models import ImpactResult, ImpactWarning
+from src.knowledge.models import ImpactResult
 from src.knowledge.queries import find_consumers_of_paths
 
 

--- a/tests/test_review_integration.py
+++ b/tests/test_review_integration.py
@@ -6,7 +6,6 @@ No running Neo4j or LLM endpoint is required.
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from src.knowledge.models import ImpactResult, ImpactWarning
 from src.reviewer.models import BugReport, ReviewOutput

--- a/tests/test_reviewer/test_review_pr_with_config.py
+++ b/tests/test_reviewer/test_review_pr_with_config.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from src.reviewer.models import ReviewOutput
 

--- a/tests/test_reviewer/test_review_pr_with_config.py
+++ b/tests/test_reviewer/test_review_pr_with_config.py
@@ -25,9 +25,7 @@ class TestReviewPrWithConfig:
     @patch("src.reviewer.agent.post_review_comments")
     @patch("src.reviewer.agent.fetch_pr_data")
     @patch("src.reviewer.agent._build_agent_with_config")
-    def test_calls_build_agent_with_injected_config(
-        self, mock_build, mock_fetch, mock_post
-    ):
+    def test_calls_build_agent_with_injected_config(self, mock_build, mock_fetch, mock_post):
         from src.reviewer.agent import review_pr_with_config
 
         mock_fetch.return_value = ("diff text", "abc123", "Fix: something")
@@ -35,9 +33,7 @@ class TestReviewPrWithConfig:
         mock_run.content = self._make_review_output()
         mock_build.return_value.run.return_value = mock_run
 
-        review_pr_with_config(
-            "owner", "repo", 1, self._PROVIDER_CONFIG, github_token="ghp-tok"
-        )
+        review_pr_with_config("owner", "repo", 1, self._PROVIDER_CONFIG, github_token="ghp-tok")
 
         mock_build.assert_called_once_with(
             self._PROVIDER_CONFIG, supports_structured_output=True, debug=False
@@ -46,9 +42,7 @@ class TestReviewPrWithConfig:
     @patch("src.reviewer.agent.post_review_comments")
     @patch("src.reviewer.agent.fetch_pr_data")
     @patch("src.reviewer.agent._build_agent_with_config")
-    def test_passes_github_token_to_fetch_pr_data(
-        self, mock_build, mock_fetch, mock_post
-    ):
+    def test_passes_github_token_to_fetch_pr_data(self, mock_build, mock_fetch, mock_post):
         from src.reviewer.agent import review_pr_with_config
 
         mock_fetch.return_value = ("diff", "sha", "title")
@@ -56,9 +50,7 @@ class TestReviewPrWithConfig:
         mock_run.content = self._make_review_output()
         mock_build.return_value.run.return_value = mock_run
 
-        review_pr_with_config(
-            "owner", "repo", 1, self._PROVIDER_CONFIG, github_token="ghp-tok"
-        )
+        review_pr_with_config("owner", "repo", 1, self._PROVIDER_CONFIG, github_token="ghp-tok")
 
         mock_fetch.assert_called_once_with("owner", "repo", 1, github_token="ghp-tok")
 
@@ -76,15 +68,13 @@ class TestReviewPrWithConfig:
 
         result = review_pr_with_config("owner", "repo", 1, self._PROVIDER_CONFIG)
 
-        assert result is expected
+        assert result == expected
         assert result.approved is True
 
     @patch("src.reviewer.agent.post_review_comments")
     @patch("src.reviewer.agent.fetch_pr_data")
     @patch("src.reviewer.agent._build_agent_with_config")
-    def test_does_not_post_comments_when_no_bugs(
-        self, mock_build, mock_fetch, mock_post
-    ):
+    def test_does_not_post_comments_when_no_bugs(self, mock_build, mock_fetch, mock_post):
         from src.reviewer.agent import review_pr_with_config
 
         mock_fetch.return_value = ("diff", "sha", "title")
@@ -110,6 +100,4 @@ class TestReviewPrBackwardCompat:
 
         sig = inspect.signature(review_pr)
         params = list(sig.parameters.keys())
-        assert params == ["owner", "repo", "pr_number"], (
-            f"review_pr() signature changed: {params}"
-        )
+        assert params == ["owner", "repo", "pr_number"], f"review_pr() signature changed: {params}"

--- a/tests/test_reviewer/test_tools_post_payload.py
+++ b/tests/test_reviewer/test_tools_post_payload.py
@@ -1,0 +1,88 @@
+"""Unit tests: post_review_comments() payload structure.
+
+Phase 2 (RED): Assert that every comment dict in the payload sent to GitHub
+contains "side": "RIGHT". This test MUST FAIL until the field is added.
+
+Phase 3 (GREEN): After adding "side": "RIGHT" in tools.py, all tests pass.
+"""
+
+import json
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.reviewer.tools import post_review_comments
+
+SAMPLE_COMMENTS = json.dumps(
+    [
+        {"path": "src/main.py", "line": 10, "body": "Missing null check"},
+        {"path": "src/utils.py", "line": 42, "body": "Inefficient loop"},
+    ]
+)
+
+
+class TestPostReviewCommentsPayload:
+    """Assert the comment dicts sent to GitHub contain 'side': 'RIGHT'."""
+
+    @patch("src.reviewer.tools.httpx.post")
+    def test_each_comment_has_side_right(self, mock_post):
+        """Every comment dict in the payload MUST have side='RIGHT'."""
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_post.return_value = mock_response
+
+        post_review_comments(
+            "owner",
+            "repo",
+            1,
+            "abc123",
+            SAMPLE_COMMENTS,
+            summary="LGTM",
+            github_token="tok",
+        )
+
+        assert mock_post.called, "httpx.post was never called"
+        actual_payload = mock_post.call_args.kwargs["json"]
+        comments_sent = actual_payload["comments"]
+
+        assert len(comments_sent) == 2, "Expected 2 comments in payload"
+        for comment in comments_sent:
+            assert "side" in comment, f"Comment dict missing 'side' field: {comment}"
+            assert comment["side"] == "RIGHT", (
+                f"Expected side='RIGHT', got side='{comment['side']}'"
+            )
+
+
+class TestPostReviewComments422Fallback:
+    """Assert that the 422 fallback posts a top-level review with empty comments."""
+
+    @patch("src.reviewer.tools.httpx.post")
+    def test_fallback_payload_has_empty_comments(self, mock_post):
+        """On 422, fallback payload must have comments=[] (no inline positions)."""
+        first_response = MagicMock()
+        first_response.status_code = 422
+        first_response.text = "Unprocessable Entity"
+
+        second_response = MagicMock()
+        second_response.status_code = 201
+        second_response.text = "ok"
+
+        mock_post.side_effect = [first_response, second_response]
+
+        result = post_review_comments(
+            "owner",
+            "repo",
+            1,
+            "abc123",
+            SAMPLE_COMMENTS,
+            summary="LGTM",
+            github_token="tok",
+        )
+
+        assert mock_post.call_count == 2, "Expected two httpx.post calls (inline + fallback)"
+
+        fallback_payload = mock_post.call_args_list[1].kwargs["json"]
+        assert fallback_payload["comments"] == [], (
+            f"Fallback payload should have empty 'comments', got: {fallback_payload['comments']}"
+        )
+        assert "top-level" in result or "inline positions" in result

--- a/tests/test_reviewer/test_tools_post_payload.py
+++ b/tests/test_reviewer/test_tools_post_payload.py
@@ -7,9 +7,8 @@ Phase 3 (GREEN): After adding "side": "RIGHT" in tools.py, all tests pass.
 """
 
 import json
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
-import pytest
 
 from src.reviewer.tools import post_review_comments
 

--- a/tests/test_reviewer/test_tools_token.py
+++ b/tests/test_reviewer/test_tools_token.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from src.reviewer.tools import fetch_pr_data, post_review_comments
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,7 +3,6 @@
 import logging
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 import src.core.config as cfg_module
 from src.reviewer.tools import fetch_pr_data

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -4,7 +4,6 @@ import hashlib
 import hmac
 import importlib
 import json
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Closes #5

## Summary

- **Fix inline comments**: add `"side": "RIGHT"` to GitHub API payload — comments now appear inline on PR diffs instead of falling back to top-level
- **Security: credentials in headers**: move `api_key` and `github_token` from request body to HTTP headers (`Authorization: Bearer`, `X-GitHub-Token`) — both headers now required, no fallback to server env vars
- **Dev tooling**: add `ruff>=0.9.0` as dev dependency with `[tool.ruff]` config; clean 21 unused imports
- **Route refactor**: move `/api/v1` prefix to `include_router`, convert `async def` to `def` to avoid event loop starvation
- **Test fixes**: correct `is` → `==` assertion, fix observability test assertion, add 8 new tests

## Changes

| File | Change |
|------|--------|
| `src/reviewer/tools.py` | Add `"side": "RIGHT"` to comment payload |
| `backend/api/v1/routes.py` | Header-based auth, sync endpoint, prefix refactor |
| `backend/models/schemas.py` | Remove `api_key`/`github_token` from body schema |
| `backend/services/reviewer.py` | Accept tokens as explicit params |
| `frontend/streamlit_app.py` | Send credentials as HTTP headers |
| `backend/main.py` | Add `prefix="/api/v1"` to router mount |
| `pyproject.toml` | Add ruff dev dep + `[tool.ruff]` config |
| `tests/test_api/` | New: 6 integration tests for header auth |
| `tests/test_reviewer/test_tools_post_payload.py` | New: 2 tests for payload `side` field |
| `tests/test_reviewer/test_review_pr_with_config.py` | Fix `is` → `==` assertion |
| `tests/test_observability.py` | Fix incorrect assertion (`project_name` → `api_key`) |
| `tests/` (various) | Remove 21 unused imports (ruff) |

## Test Plan

- [x] 55 tests passing (no regressions)
- [x] `ruff check src/ backend/ tests/` — clean
- [x] Inline comments post correctly with `side: "RIGHT"`
- [x] Missing `Authorization` → 422
- [x] Missing `X-GitHub-Token` → 422
- [x] Empty `X-GitHub-Token` → 401
- [x] Frontend sends both headers on every request