### PR TITLE
fix(review): harden judgment day follow-ups

### DIFF
--- a/backend/api/v1/routes.py
+++ b/backend/api/v1/routes.py
@@ -24,6 +24,8 @@ def review_pr(
 ) -> ReviewResponse:
     """Run a code review on the given pull request."""
     api_key = re.sub(r"(?i)^bearer\s+", "", authorization).strip()
+    if not api_key:
+        raise HTTPException(status_code=401, detail="API key must be non-empty")
     if not x_github_token.strip():
         raise HTTPException(status_code=401, detail="X-GitHub-Token must be non-empty")
     return run_review(req, api_key=api_key, github_token=x_github_token)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -32,10 +32,17 @@ class BackendConfig:
     NEO4J_USER: str = os.getenv("NEO4J_USER", "neo4j")
     NEO4J_PASSWORD: str = os.getenv("NEO4J_PASSWORD", "")
 
+    @classmethod
+    def validate(cls) -> None:
+        """Validate required configuration. Raises ValueError if invalid."""
+        if cls.ENABLE_GRAPH_ENRICHMENT:
+            if not cls.NEO4J_PASSWORD:
+                raise ValueError("NEO4J_PASSWORD is required when ENABLE_GRAPH_ENRICHMENT is true")
+            if not cls.NEO4J_URI:
+                raise ValueError("NEO4J_URI is required when ENABLE_GRAPH_ENRICHMENT is true")
+
     # Knowledge Graph
-    ENABLE_GRAPH_ENRICHMENT: bool = (
-        os.getenv("ENABLE_GRAPH_ENRICHMENT", "false").lower() == "true"
-    )
+    ENABLE_GRAPH_ENRICHMENT: bool = os.getenv("ENABLE_GRAPH_ENRICHMENT", "false").lower() == "true"
     GRAPH_QUERY_TIMEOUT: int = int(os.getenv("GRAPH_QUERY_TIMEOUT", "5"))
     MAX_IMPACT_WARNINGS: int = int(os.getenv("MAX_IMPACT_WARNINGS", "10"))
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,6 +64,17 @@ async def lifespan(app: FastAPI):
     """
     configure_logging(Config.LOG_LEVEL)
     configure_opik()
+
+    try:
+        Config.validate()
+    except ValueError as exc:
+        logger.warning("Config validation warning: %s", exc)
+
+    try:
+        BackendConfig.validate()
+    except ValueError as exc:
+        logger.warning("BackendConfig validation warning: %s", exc)
+
     logger.info("PR Reviewer backend started")
     yield
 
@@ -119,10 +130,7 @@ async def github_webhook(
         )
         trusted = {"OWNER", "MEMBER", "COLLABORATOR"}
     if author_association not in trusted:
-        return {
-            "status": "skipped",
-            "reason": f"untrusted author association: {author_association}",
-        }
+        return {"status": "skipped"}
 
     owner, repo = repo_full.split("/", 1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,16 @@ description = "PR Code Reviewer"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "agno>=1.7.0",
+    "openai>=1.0.0",
     "opik",
     "openinference-instrumentation-agno",
+    "pygithub>=2.0.0",
+    "httpx>=0.28.0",
+    "fastapi[standard]>=0.115.0",
+    "python-dotenv>=1.2.1",
+    "neo4j>=5.0.0",
+    "pyyaml>=6.0",
 ]
 
 [dependency-groups]

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -35,10 +35,17 @@ class Config:
     NEO4J_USER: str = os.getenv("NEO4J_USER", "neo4j")
     NEO4J_PASSWORD: str = os.getenv("NEO4J_PASSWORD", "")
 
+    @classmethod
+    def validate(cls) -> None:
+        """Validate required configuration. Raises ValueError if invalid."""
+        if cls.ENABLE_GRAPH_ENRICHMENT:
+            if not cls.NEO4J_PASSWORD:
+                raise ValueError("NEO4J_PASSWORD is required when ENABLE_GRAPH_ENRICHMENT is true")
+            if not cls.NEO4J_URI:
+                raise ValueError("NEO4J_URI is required when ENABLE_GRAPH_ENRICHMENT is true")
+
     # Knowledge Graph
-    ENABLE_GRAPH_ENRICHMENT: bool = (
-        os.getenv("ENABLE_GRAPH_ENRICHMENT", "false").lower() == "true"
-    )
+    ENABLE_GRAPH_ENRICHMENT: bool = os.getenv("ENABLE_GRAPH_ENRICHMENT", "false").lower() == "true"
     GRAPH_QUERY_TIMEOUT: int = int(os.getenv("GRAPH_QUERY_TIMEOUT", "5"))
     MAX_IMPACT_WARNINGS: int = int(os.getenv("MAX_IMPACT_WARNINGS", "10"))
 

--- a/src/knowledge/client.py
+++ b/src/knowledge/client.py
@@ -1,6 +1,7 @@
 """Neo4j driver singleton wrapper with lazy initialization and health checks."""
 
 import logging
+import time
 
 from neo4j import Driver, GraphDatabase
 from neo4j.exceptions import (
@@ -17,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 _driver: Driver | None = None
 
+_health_cache: tuple[bool, float] | None = None
+_HEALTH_CACHE_TTL = 30
+
 
 def get_driver() -> Driver:
     """Returns the singleton Neo4j driver, creating it on first call.
@@ -32,6 +36,9 @@ def get_driver() -> Driver:
         _driver = GraphDatabase.driver(
             Config.NEO4J_URI,
             auth=(Config.NEO4J_USER, Config.NEO4J_PASSWORD),
+            max_connection_lifetime=3600,
+            max_connection_pool_size=50,
+            connection_acquisition_timeout=60,
         )
         return _driver
     except (DriverError, AuthError) as exc:
@@ -51,17 +58,29 @@ def close_driver() -> None:
 
 
 def check_health() -> bool:
-    """Verifies Neo4j connectivity. Returns True if reachable, False otherwise.
+    """Verifies Neo4j connectivity with caching. Returns True if reachable, False otherwise.
 
+    Uses a TTL cache to distinguish repeated failures from "not configured".
     Never raises — all exceptions are caught and logged.
     """
+    global _health_cache
+
+    now = time.monotonic()
+    if _health_cache is not None:
+        cached_result, cached_time = _health_cache
+        if now - cached_time < _HEALTH_CACHE_TTL:
+            return cached_result
+
     try:
         driver = get_driver()
         driver.verify_connectivity()
+        _health_cache = (True, now)
         return True
     except (GraphError, ServiceUnavailable, DriverError, ClientError, OSError) as exc:
         logger.warning("Neo4j health check failed: %s", exc)
+        _health_cache = (False, now)
         return False
     except Exception as exc:
         logger.warning("Unexpected error during Neo4j health check: %s", exc)
+        _health_cache = (False, now)
         return False

--- a/src/knowledge/population.py
+++ b/src/knowledge/population.py
@@ -68,8 +68,7 @@ def _populate_tx(tx: ManagedTransaction, topology: TopologyConfig) -> dict:
     for repo_def in topology.repositories:
         # MERGE Repository
         tx.run(
-            f"MERGE (r:{REPOSITORY} {{name: $name}}) "
-            f"SET r.description = $description",
+            f"MERGE (r:{REPOSITORY} {{name: $name}}) SET r.description = $description",
             name=repo_def.name,
             description=repo_def.description,
         )
@@ -147,6 +146,7 @@ def _populate_tx(tx: ManagedTransaction, topology: TopologyConfig) -> dict:
             for contract_name in svc_def.consumes:
                 tx.run(
                     f"MERGE (c:{CONTRACT} {{name: $contract_name}}) "
+                    f"SET c.file_path = null "
                     f"WITH c "
                     f"MATCH (s:{SERVICE} {{name: $svc_name}}) "
                     f"MERGE (s)-[:{CONSUMES}]->(c)",

--- a/src/knowledge/population.py
+++ b/src/knowledge/population.py
@@ -146,7 +146,6 @@ def _populate_tx(tx: ManagedTransaction, topology: TopologyConfig) -> dict:
             for contract_name in svc_def.consumes:
                 tx.run(
                     f"MERGE (c:{CONTRACT} {{name: $contract_name}}) "
-                    f"SET c.file_path = null "
                     f"WITH c "
                     f"MATCH (s:{SERVICE} {{name: $svc_name}}) "
                     f"MERGE (s)-[:{CONSUMES}]->(c)",

--- a/src/reviewer/agent.py
+++ b/src/reviewer/agent.py
@@ -1,7 +1,9 @@
 import html
 import json
 import logging
+import os
 import re
+from pathlib import Path
 
 from agno.agent import Agent
 from agno.models.openai.like import OpenAILike
@@ -13,6 +15,15 @@ from src.reviewer.prompts import REVIEWER_INSTRUCTIONS, _build_impact_section
 from src.reviewer.tools import fetch_pr_data, post_review_comments
 
 logger = logging.getLogger(__name__)
+
+
+def _log_full_llm_response(raw: str, owner: str, repo: str, pr_number: int) -> None:
+    """Log full raw LLM response to a file for debugging."""
+    log_dir = Path("/tmp/pr-reviewer-logs")
+    log_dir.mkdir(exist_ok=True)
+    log_file = log_dir / f"llm-fail-{owner}-{repo}-{pr_number}.txt"
+    log_file.write_text(raw)
+    logger.warning("Agent returned unparseable output. Full response logged to %s", log_file)
 
 
 def _build_agent(debug: bool = False) -> Agent:
@@ -99,7 +110,13 @@ def _bugs_to_comments(bugs: list[BugReport]) -> list[dict]:
 def _run_llm(agent: Agent, prompt: str) -> str:
     """Run the agent and return the raw response content as a string."""
     run = agent.run(prompt)
-    return run.content if isinstance(run.content, str) else json.dumps(run.content.model_dump() if hasattr(run.content, "model_dump") else run.content)
+    return (
+        run.content
+        if isinstance(run.content, str)
+        else json.dumps(
+            run.content.model_dump() if hasattr(run.content, "model_dump") else run.content
+        )
+    )
 
 
 def _extract_changed_paths(diff_text: str) -> list[str]:
@@ -134,14 +151,11 @@ def _extract_changed_paths(diff_text: str) -> list[str]:
     return paths
 
 
-@track_if_enabled()
-def review_pr(owner: str, repo: str, pr_number: int) -> ReviewOutput:
-    """Run the reviewer on the given pull request (silent mode)."""
-    # Step 1: fetch diff programmatically
-    diff_text, head_sha, pr_title = fetch_pr_data(owner, repo, pr_number)
-
-    # Step 2: graph enrichment (optional, behind feature toggle)
-    prompt = _make_prompt(pr_title, diff_text)
+def _enrich_with_graph(
+    diff_text: str,
+) -> tuple[str, list | None]:
+    """Enrich prompt with graph data if available. Returns (prompt, impact_result)."""
+    prompt = ""
     impact_result = None
 
     if Config.ENABLE_GRAPH_ENRICHMENT:
@@ -161,12 +175,25 @@ def review_pr(owner: str, repo: str, pr_number: int) -> ReviewOutput:
                     if impact_result.warnings:
                         impact_section = _build_impact_section(impact_result)
                         if impact_section:
-                            prompt = impact_section + "\n\n" + prompt
+                            prompt = impact_section + "\n\n"
             else:
                 logger.warning("Graph enrichment skipped: Neo4j is not reachable.")
         except Exception as exc:
             logger.warning("Graph enrichment failed — continuing without it: %s", exc)
             impact_result = None
+
+    return prompt, impact_result
+
+
+@track_if_enabled()
+def review_pr(owner: str, repo: str, pr_number: int) -> ReviewOutput:
+    """Run the reviewer on the given pull request (silent mode)."""
+    # Step 1: fetch diff programmatically
+    diff_text, head_sha, pr_title = fetch_pr_data(owner, repo, pr_number)
+
+    # Step 2: graph enrichment (optional, behind feature toggle)
+    impact_section, impact_result = _enrich_with_graph(diff_text)
+    prompt = impact_section + _make_prompt(pr_title, diff_text)
 
     # Step 3: run LLM analysis with structured output
     agent = _build_agent(debug=False)
@@ -176,12 +203,14 @@ def review_pr(owner: str, repo: str, pr_number: int) -> ReviewOutput:
         data = json.loads(raw)
         result = ReviewOutput(**data)
     except Exception:
-        logger.warning("Agent returned unparseable output: %s", raw[:200])
+        _log_full_llm_response(raw, owner, repo, pr_number)
         result = ReviewOutput(
-            summary=f"Error: Agent failed to produce valid output. Raw response: {raw[:500]}",
+            summary=f"Error: Agent failed to produce valid output.",
             bugs=[],
             approved=False,
+            impact_warnings=[],
         )
+        return result
 
     # Step 4: attach impact warnings to result
     if impact_result is not None:
@@ -231,37 +260,11 @@ def review_pr_with_config(
         ReviewOutput with bugs, summary, and approval status.
     """
     # Step 1: fetch diff
-    diff_text, head_sha, pr_title = fetch_pr_data(
-        owner, repo, pr_number, github_token=github_token
-    )
+    diff_text, head_sha, pr_title = fetch_pr_data(owner, repo, pr_number, github_token=github_token)
 
     # Step 2: graph enrichment (optional, behind feature toggle — same as review_pr)
-    prompt = _make_prompt(pr_title, diff_text)
-    impact_result = None
-
-    if Config.ENABLE_GRAPH_ENRICHMENT:
-        try:
-            from src.knowledge.client import check_health, get_driver
-            from src.knowledge.queries import find_consumers_of_paths
-
-            if check_health():
-                changed_paths = _extract_changed_paths(diff_text)
-                if changed_paths:
-                    driver = get_driver()
-                    impact_result = find_consumers_of_paths(
-                        driver,
-                        changed_paths,
-                        timeout=Config.GRAPH_QUERY_TIMEOUT,
-                    )
-                    if impact_result.warnings:
-                        impact_section = _build_impact_section(impact_result)
-                        if impact_section:
-                            prompt = impact_section + "\n\n" + prompt
-            else:
-                logger.warning("Graph enrichment skipped: Neo4j is not reachable.")
-        except Exception as exc:
-            logger.warning("Graph enrichment failed — continuing without it: %s", exc)
-            impact_result = None
+    impact_section, impact_result = _enrich_with_graph(diff_text)
+    prompt = impact_section + _make_prompt(pr_title, diff_text)
 
     # Step 3: run LLM analysis with injected config
     agent = _build_agent_with_config(
@@ -275,12 +278,14 @@ def review_pr_with_config(
         data = json.loads(raw)
         result = ReviewOutput(**data)
     except Exception:
-        logger.warning("Agent returned unparseable output: %s", raw[:200])
+        _log_full_llm_response(raw, owner, repo, pr_number)
         result = ReviewOutput(
-            summary=f"Error: Agent failed to produce valid output. Raw response: {raw[:500]}",
+            summary=f"Error: Agent failed to produce valid output.",
             bugs=[],
             approved=False,
+            impact_warnings=[],
         )
+        return result
 
     # Step 4: attach impact warnings
     if impact_result is not None:

--- a/src/reviewer/agent.py
+++ b/src/reviewer/agent.py
@@ -17,13 +17,39 @@ from src.reviewer.tools import fetch_pr_data, post_review_comments
 logger = logging.getLogger(__name__)
 
 
+def _debug_raw_llm_logging_enabled() -> bool:
+    return os.getenv("PR_REVIEWER_LOG_RAW_LLM_FAILURES", "false").lower() == "true"
+
+
 def _log_full_llm_response(raw: str, owner: str, repo: str, pr_number: int) -> None:
     """Log full raw LLM response to a file for debugging."""
+    if not _debug_raw_llm_logging_enabled():
+        preview = " ".join(raw.split())[:200]
+        logger.warning(
+            "Agent returned unparseable output for %s/%s#%d. Response length=%d preview=%r",
+            owner,
+            repo,
+            pr_number,
+            len(raw),
+            preview,
+        )
+        return
+
     log_dir = Path("/tmp/pr-reviewer-logs")
     log_dir.mkdir(exist_ok=True)
     log_file = log_dir / f"llm-fail-{owner}-{repo}-{pr_number}.txt"
     log_file.write_text(raw)
     logger.warning("Agent returned unparseable output. Full response logged to %s", log_file)
+
+
+def _parse_failure_result(impact_result) -> ReviewOutput:
+    warnings = impact_result.warnings if impact_result is not None else []
+    return ReviewOutput(
+        summary="Error: Agent failed to produce valid output.",
+        bugs=[],
+        approved=False,
+        impact_warnings=warnings,
+    )
 
 
 def _build_agent(debug: bool = False) -> Agent:
@@ -204,12 +230,7 @@ def review_pr(owner: str, repo: str, pr_number: int) -> ReviewOutput:
         result = ReviewOutput(**data)
     except Exception:
         _log_full_llm_response(raw, owner, repo, pr_number)
-        result = ReviewOutput(
-            summary=f"Error: Agent failed to produce valid output.",
-            bugs=[],
-            approved=False,
-            impact_warnings=[],
-        )
+        result = _parse_failure_result(impact_result)
         return result
 
     # Step 4: attach impact warnings to result
@@ -279,12 +300,7 @@ def review_pr_with_config(
         result = ReviewOutput(**data)
     except Exception:
         _log_full_llm_response(raw, owner, repo, pr_number)
-        result = ReviewOutput(
-            summary=f"Error: Agent failed to produce valid output.",
-            bugs=[],
-            approved=False,
-            impact_warnings=[],
-        )
+        result = _parse_failure_result(impact_result)
         return result
 
     # Step 4: attach impact warnings

--- a/src/reviewer/tools.py
+++ b/src/reviewer/tools.py
@@ -10,6 +10,20 @@ from src.core.config import Config
 logger = logging.getLogger(__name__)
 
 
+def _post_review_with_retry(url: str, headers: dict, json: dict) -> httpx.Response:
+    """Post to GitHub API with retry logic."""
+    for attempt in range(3):
+        try:
+            response = httpx.post(url, headers=headers, json=json, timeout=30)
+            if response.status_code < 500:
+                return response
+        except httpx.RequestError as exc:
+            logger.warning("GitHub API request failed (attempt %d): %s", attempt + 1, exc)
+        except Exception as exc:
+            logger.warning("Unexpected error calling GitHub API: %s", exc)
+    return httpx.Response(503, text="Service unavailable after retries")
+
+
 def fetch_pr_data(
     owner: str, repo: str, pr_number: int, github_token: str = ""
 ) -> tuple[str, str, str]:
@@ -40,18 +54,30 @@ def fetch_pr_data(
 
     diff_text = "\n\n".join(diff_parts)
 
-    # L5: Truncate oversized diffs
+    # L5: Truncate oversized diffs at file boundary
     max_chars = Config.MAX_DIFF_CHARS
-    if len(diff_text) > max_chars:
+    original_len = len(diff_text)
+    if original_len > max_chars:
+        truncated_parts = []
+        current_chars = 0
+        for part in diff_parts:
+            if current_chars + len(part) > max_chars:
+                remaining = max_chars - current_chars
+                if remaining > 0:
+                    truncated_parts.append(part[:remaining])
+                break
+            truncated_parts.append(part)
+            current_chars += len(part)
+        diff_text = "\n\n".join(truncated_parts)
+        diff_text += "\n\n[TRUNCATED — diff exceeded size limit]"
         logger.warning(
             "Diff for %s/%s#%d truncated: %d → %d chars",
             owner,
             repo,
             pr_number,
-            len(diff_text),
+            original_len,
             max_chars,
         )
-        diff_text = diff_text[:max_chars] + "\n\n[TRUNCATED — diff exceeded size limit]"
 
     return diff_text, head_sha, pr_title
 
@@ -105,14 +131,12 @@ def post_review_comments(
         ],
     }
 
-    response = httpx.post(url, headers=headers, json=payload, timeout=30)
+    response = _post_review_with_retry(url, headers=headers, json=payload)
 
     if response.status_code in (200, 201):
         return f"Review posted successfully on PR #{pr_number} in {owner}/{repo}."
 
     if response.status_code == 422:
-        # Line numbers from the LLM may not match the diff — fall back to a
-        # top-level review comment listing all bugs without inline positions.
         logger.warning(
             "Inline comments rejected by GitHub (422 - line not in diff). "
             "Falling back to top-level review comment."
@@ -126,7 +150,7 @@ def post_review_comments(
             "event": "COMMENT",
             "comments": [],
         }
-        fallback = httpx.post(url, headers=headers, json=fallback_payload, timeout=30)
+        fallback = _post_review_with_retry(url, headers=headers, json=fallback_payload)
         if fallback.status_code in (200, 201):
             return f"Review posted as top-level comment on PR #{pr_number} (inline positions not in diff)."
         return f"GitHub API error {fallback.status_code}: {fallback.text}"

--- a/src/reviewer/tools.py
+++ b/src/reviewer/tools.py
@@ -10,6 +10,9 @@ from src.core.config import Config
 logger = logging.getLogger(__name__)
 
 
+TRUNCATION_MARKER = "\n\n[TRUNCATED - diff exceeded size limit]"
+
+
 def _post_review_with_retry(url: str, headers: dict, json: dict) -> httpx.Response:
     """Post to GitHub API with retry logic."""
     for attempt in range(3):
@@ -60,16 +63,16 @@ def fetch_pr_data(
     if original_len > max_chars:
         truncated_parts = []
         current_chars = 0
+        content_budget = max(max_chars - len(TRUNCATION_MARKER), 0)
         for part in diff_parts:
-            if current_chars + len(part) > max_chars:
-                remaining = max_chars - current_chars
-                if remaining > 0:
-                    truncated_parts.append(part[:remaining])
+            separator_len = 0 if not truncated_parts else 2
+            part_len = separator_len + len(part)
+            if current_chars + part_len > content_budget:
                 break
             truncated_parts.append(part)
-            current_chars += len(part)
+            current_chars += part_len
         diff_text = "\n\n".join(truncated_parts)
-        diff_text += "\n\n[TRUNCATED — diff exceeded size limit]"
+        diff_text += TRUNCATION_MARKER[: max_chars - len(diff_text)]
         logger.warning(
             "Diff for %s/%s#%d truncated: %d → %d chars",
             owner,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,8 +1,11 @@
-"""Unit tests: L3 (XML delimiters) and L4 (title sanitization) in agent.py."""
+"""Unit tests: agent prompt, sanitization, and parse-failure behavior."""
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.reviewer.agent import _make_prompt, _sanitize_title
+from src.knowledge.models import ImpactResult, ImpactWarning
+from src.reviewer.agent import _log_full_llm_response, _make_prompt, _sanitize_title
 
 
 # ---------------------------------------------------------------------------
@@ -187,3 +190,54 @@ class TestMakePrompt:
         prompt = _make_prompt(malicious_title, "diff")
         assert prompt.count("<pr_title>") == 1  # only the real opening tag
         assert "&lt;pr_title&gt;" in prompt
+
+
+class TestParseFailureLogging:
+    def test_raw_response_is_not_written_to_disk_without_debug_flag(self, monkeypatch, caplog):
+        monkeypatch.delenv("PR_REVIEWER_LOG_RAW_LLM_FAILURES", raising=False)
+
+        with (
+            patch("src.reviewer.agent.Path.mkdir") as mock_mkdir,
+            patch("pathlib.Path.write_text") as mock_write_text,
+            caplog.at_level("WARNING", logger="src.reviewer.agent"),
+        ):
+            _log_full_llm_response("secret response\nwith details", "owner", "repo", 7)
+
+        mock_mkdir.assert_not_called()
+        mock_write_text.assert_not_called()
+        assert "Response length=" in " ".join(caplog.messages)
+
+
+class TestParseFailureImpactWarnings:
+    def test_review_pr_preserves_impact_warnings_on_parse_failure(self, monkeypatch):
+        warning = ImpactWarning(
+            changed_file="src/contracts/order.py",
+            changed_entity="OrderCreated",
+            affected_service="payment-worker",
+            affected_repository="payment-service",
+            relationship_type="CONSUMES",
+            description="`payment-worker` consumes `OrderCreated`.",
+        )
+        impact_result = ImpactResult(warnings=[warning], query_time_ms=1.0)
+        monkeypatch.setattr("src.core.config.Config.ENABLE_GRAPH_ENRICHMENT", True)
+
+        with (
+            patch("src.reviewer.agent.fetch_pr_data", return_value=("### src/contracts/order.py\npatch", "sha", "PR")),
+            patch("src.reviewer.agent._build_agent") as mock_build_agent,
+            patch("src.reviewer.agent.post_review_comments"),
+            patch("src.knowledge.client.check_health", return_value=True),
+            patch("src.knowledge.client.get_driver", return_value=object()),
+            patch("src.knowledge.queries.find_consumers_of_paths", return_value=impact_result),
+            patch("src.reviewer.agent._log_full_llm_response"),
+        ):
+            mock_run = MagicMock()
+            mock_run.content = "not json"
+            mock_build_agent.return_value.run = MagicMock(return_value=mock_run)
+
+            from src.reviewer.agent import review_pr
+
+            result = review_pr("owner", "repo", 1)
+
+        assert result.approved is False
+        assert result.summary == "Error: Agent failed to produce valid output."
+        assert result.impact_warnings == [warning]

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -141,7 +141,13 @@ def _make_topology_with_consumer() -> TopologyConfig:
                 services=[
                     ServiceDef(
                         name="producer-svc",
-                        produces=[ContractDef(name="SharedContract", type="event")],
+                        produces=[
+                            ContractDef(
+                                name="SharedContract",
+                                file_path="src/contracts/shared_contract.py",
+                                type="event",
+                            )
+                        ],
                         consumes=[],
                     )
                 ],
@@ -261,6 +267,15 @@ class TestPopulateGraph:
         calls_args = [str(c) for c in mock_tx.run.call_args_list]
         consumes_calls = [c for c in calls_args if "CONSUMES" in c]
         assert len(consumes_calls) >= 1, "Expected at least one MERGE for CONSUMES relationship"
+
+    def test_populate_graph_consumer_merge_does_not_clear_producer_file_path(self):
+        driver, mock_tx = self._make_mock_driver()
+        topology = _make_topology_with_consumer()
+        populate_graph(driver, topology)
+
+        consumes_queries = [call.args[0] for call in mock_tx.run.call_args_list if "CONSUMES" in call.args[0]]
+        assert len(consumes_queries) == 1
+        assert "SET c.file_path = null" not in consumes_queries[0]
 
     def test_populate_graph_field_nodes_are_merged(self):
         driver, mock_tx = self._make_mock_driver()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 
 import src.core.config as cfg_module
-from src.reviewer.tools import fetch_pr_data
+from src.reviewer.tools import TRUNCATION_MARKER, fetch_pr_data
 
 
 # ---------------------------------------------------------------------------
@@ -24,6 +24,13 @@ def _make_mock_pr(patch_text: str, title: str = "Test PR", sha: str = "deadbeef"
     mock_pr.title = title
     mock_pr.get_files.return_value = [mock_file]
     return mock_pr
+
+
+def _make_mock_file(filename: str, patch_text: str):
+    mock_file = MagicMock()
+    mock_file.filename = filename
+    mock_file.patch = patch_text
+    return mock_file
 
 
 # ---------------------------------------------------------------------------
@@ -50,21 +57,26 @@ class TestDiffTruncation:
 
     @patch("src.reviewer.tools.Github")
     def test_long_diff_is_truncated(self, mock_github_cls, monkeypatch):
-        """SC-L5-2: A diff exceeding MAX_DIFF_CHARS is cut and ends with [TRUNCATED]."""
-        limit = 500
+        """SC-L5-2: A diff exceeding MAX_DIFF_CHARS truncates at file boundary."""
+        first_part = "### src/a.py\n" + ("a" * 40)
+        second_part = "### src/b.py\n" + ("b" * 200)
+        limit = len(first_part) + len(TRUNCATION_MARKER)
         monkeypatch.setattr(cfg_module.Config, "MAX_DIFF_CHARS", limit)
 
-        patch_text = "y" * 10_000
-        mock_github_cls.return_value.get_repo.return_value.get_pull.return_value = (
-            _make_mock_pr(patch_text)
-        )
+        mock_pr = MagicMock()
+        mock_pr.head.sha = "deadbeef"
+        mock_pr.title = "Test PR"
+        mock_pr.get_files.return_value = [
+            _make_mock_file("src/a.py", "a" * 40),
+            _make_mock_file("src/b.py", "b" * 200),
+        ]
+        mock_github_cls.return_value.get_repo.return_value.get_pull.return_value = mock_pr
 
         diff_text, _, _ = fetch_pr_data("owner", "repo", 1, github_token="tok")
 
-        assert diff_text.endswith("[TRUNCATED — diff exceeded size limit]")
-        # Content up to the limit + marker — must not exceed limit + marker length
-        marker = "\n\n[TRUNCATED — diff exceeded size limit]"
-        assert len(diff_text) == limit + len(marker)
+        assert diff_text == first_part + TRUNCATION_MARKER
+        assert "src/b.py" not in diff_text
+        assert len(diff_text) == limit
 
     @patch("src.reviewer.tools.Github")
     def test_truncation_emits_warning(self, mock_github_cls, monkeypatch, caplog):
@@ -100,9 +112,8 @@ class TestDiffTruncation:
 
         diff_text, _, _ = fetch_pr_data("owner", "repo", 1, github_token="tok")
 
-        marker = "\n\n[TRUNCATED — diff exceeded size limit]"
-        assert len(diff_text) == custom_limit + len(marker)
-        assert diff_text.endswith("[TRUNCATED — diff exceeded size limit]")
+        assert len(diff_text) <= custom_limit
+        assert diff_text == TRUNCATION_MARKER
 
     @patch("src.reviewer.tools.Github")
     def test_diff_exactly_at_limit_is_not_truncated(self, mock_github_cls, monkeypatch):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -74,9 +74,7 @@ class TestAuthorAssociationGating:
         """SC-L1-1: OWNER association → review_pr() is called."""
         _, _, main_module = client
         mock_result = MagicMock(approved=True, bugs=[], summary="ok")
-        with patch.object(
-            main_module, "review_pr", return_value=mock_result
-        ) as mock_review:
+        with patch.object(main_module, "review_pr", return_value=mock_result) as mock_review:
             resp = _post(client, _make_payload("OWNER"))
 
         assert resp.status_code == 202
@@ -87,9 +85,7 @@ class TestAuthorAssociationGating:
         """SC-L1-1 (MEMBER): MEMBER association → review_pr() is called."""
         _, _, main_module = client
         mock_result = MagicMock(approved=True, bugs=[], summary="ok")
-        with patch.object(
-            main_module, "review_pr", return_value=mock_result
-        ) as mock_review:
+        with patch.object(main_module, "review_pr", return_value=mock_result) as mock_review:
             resp = _post(client, _make_payload("MEMBER"))
 
         assert resp.status_code == 202
@@ -100,9 +96,7 @@ class TestAuthorAssociationGating:
         """SC-L1-1 (COLLABORATOR): COLLABORATOR association → review_pr() is called."""
         _, _, main_module = client
         mock_result = MagicMock(approved=True, bugs=[], summary="ok")
-        with patch.object(
-            main_module, "review_pr", return_value=mock_result
-        ) as mock_review:
+        with patch.object(main_module, "review_pr", return_value=mock_result) as mock_review:
             resp = _post(client, _make_payload("COLLABORATOR"))
 
         assert resp.status_code == 202
@@ -118,7 +112,7 @@ class TestAuthorAssociationGating:
         assert resp.status_code == 202
         data = resp.json()
         assert data["status"] == "skipped"
-        assert "untrusted" in data["reason"]
+        # No reason field - security: don't leak trust config to untrusted authors
         mock_review.assert_not_called()
 
     def test_first_timer_skips_review(self, client):
@@ -185,18 +179,14 @@ class TestAuthorAssociationGating:
         monkeypatch.setattr(cfg_module.Config, "TRUSTED_AUTHOR_ASSOCIATIONS", "")
 
         mock_result = MagicMock(approved=True, bugs=[], summary="ok")
-        with patch.object(
-            main_module, "review_pr", return_value=mock_result
-        ) as mock_review:
+        with patch.object(main_module, "review_pr", return_value=mock_result) as mock_review:
             resp = _post(client, _make_payload("OWNER"))
 
         assert resp.status_code == 202
         assert resp.json()["status"] == "reviewed"
         mock_review.assert_called_once()
 
-    def test_lowercase_trusted_list_matches_uppercase_association(
-        self, client, monkeypatch
-    ):
+    def test_lowercase_trusted_list_matches_uppercase_association(self, client, monkeypatch):
         """Case-insensitivity: lowercase env var values must match GitHub's uppercase values."""
         _, _, main_module = client
         import src.core.config as cfg_module
@@ -208,9 +198,7 @@ class TestAuthorAssociationGating:
         )
 
         mock_result = MagicMock(approved=True, bugs=[], summary="ok")
-        with patch.object(
-            main_module, "review_pr", return_value=mock_result
-        ) as mock_review:
+        with patch.object(main_module, "review_pr", return_value=mock_result) as mock_review:
             resp = _post(client, _make_payload("OWNER"))
 
         assert resp.status_code == 202
@@ -222,9 +210,7 @@ class TestAuthorAssociationGating:
         _, _, main_module = client
         import src.core.config as cfg_module
 
-        monkeypatch.setattr(
-            cfg_module.Config, "TRUSTED_AUTHOR_ASSOCIATIONS", "OWNER,MEMBER"
-        )
+        monkeypatch.setattr(cfg_module.Config, "TRUSTED_AUTHOR_ASSOCIATIONS", "OWNER,MEMBER")
 
         with patch.object(main_module, "review_pr") as mock_review:
             resp = _post(client, _make_payload("CONTRIBUTOR"))
@@ -238,14 +224,10 @@ class TestAuthorAssociationGating:
         _, _, main_module = client
         import src.core.config as cfg_module
 
-        monkeypatch.setattr(
-            cfg_module.Config, "TRUSTED_AUTHOR_ASSOCIATIONS", "OWNER,MEMBER"
-        )
+        monkeypatch.setattr(cfg_module.Config, "TRUSTED_AUTHOR_ASSOCIATIONS", "OWNER,MEMBER")
 
         mock_result = MagicMock(approved=True, bugs=[], summary="ok")
-        with patch.object(
-            main_module, "review_pr", return_value=mock_result
-        ) as mock_review:
+        with patch.object(main_module, "review_pr", return_value=mock_result) as mock_review:
             resp = _post(client, _make_payload("OWNER"))
 
         assert resp.status_code == 202

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -112,6 +112,7 @@ class TestAuthorAssociationGating:
         assert resp.status_code == 202
         data = resp.json()
         assert data["status"] == "skipped"
+        assert "reason" not in data
         # No reason field - security: don't leak trust config to untrusted authors
         mock_review.assert_not_called()
 
@@ -122,7 +123,9 @@ class TestAuthorAssociationGating:
             resp = _post(client, _make_payload("FIRST_TIMER"))
 
         assert resp.status_code == 202
-        assert resp.json()["status"] == "skipped"
+        data = resp.json()
+        assert data["status"] == "skipped"
+        assert "reason" not in data
         mock_review.assert_not_called()
 
     def test_first_time_contributor_skips_review(self, client):
@@ -132,7 +135,9 @@ class TestAuthorAssociationGating:
             resp = _post(client, _make_payload("FIRST_TIME_CONTRIBUTOR"))
 
         assert resp.status_code == 202
-        assert resp.json()["status"] == "skipped"
+        data = resp.json()
+        assert data["status"] == "skipped"
+        assert "reason" not in data
         mock_review.assert_not_called()
 
     def test_missing_author_association_defaults_to_skip(self, client):
@@ -142,7 +147,9 @@ class TestAuthorAssociationGating:
             resp = _post(client, _make_payload(None))
 
         assert resp.status_code == 202
-        assert resp.json()["status"] == "skipped"
+        data = resp.json()
+        assert data["status"] == "skipped"
+        assert "reason" not in data
         mock_review.assert_not_called()
 
     def test_null_author_association_is_skipped(self, client):
@@ -158,7 +165,9 @@ class TestAuthorAssociationGating:
             resp = _post(client, payload)
 
         assert resp.status_code == 202
-        assert resp.json()["status"] == "skipped"
+        data = resp.json()
+        assert data["status"] == "skipped"
+        assert "reason" not in data
         mock_review.assert_not_called()
 
     def test_contributor_blocked_with_default_config(self, client):
@@ -168,7 +177,9 @@ class TestAuthorAssociationGating:
             resp = _post(client, _make_payload("CONTRIBUTOR"))
 
         assert resp.status_code == 202
-        assert resp.json()["status"] == "skipped"
+        data = resp.json()
+        assert data["status"] == "skipped"
+        assert "reason" not in data
         mock_review.assert_not_called()
 
     def test_empty_trusted_list_falls_back_to_default(self, client, monkeypatch):


### PR DESCRIPTION
## Summary
- Harden follow-up fixes from Judgment Day review for auth, webhook handling, graph enrichment, LLM parse failures, and GitHub retries.
- Preserve graph contract metadata and impact warnings across failure paths.
- Temporarily add backend runtime dependencies to the root test environment so current root-level tests can run.

## Test Plan
- [x] `uv run python -m pytest tests/test_population.py tests/test_tools.py tests/test_agent.py tests/test_webhook.py`

## Notes
- Opened without linked issue by maintainer request; issue validation may fail.